### PR TITLE
#8-removeOldPhotoFromCloudinary

### DIFF
--- a/src/consts/models.js
+++ b/src/consts/models.js
@@ -12,7 +12,8 @@ const refs = {
   FINISHED_QUIZ: 'FinishedQuiz',
   ATTACHMENT: 'Attachment',
   QUESTION: 'Question',
-  RESOURCES_CATEGORY: 'ResourcesCategory'
+  RESOURCES_CATEGORY: 'ResourcesCategory',
+  IMAGE: 'Image'
 }
 
 module.exports = refs

--- a/src/controllers/uploadImage.js
+++ b/src/controllers/uploadImage.js
@@ -1,13 +1,14 @@
 const { INTERNAL_SERVER_ERROR, NO_FILE_UPLOADED } = require('~/consts/errors')
 const { createError } = require('~/utils/errorsHelper')
 const { upload } = require('~/utils/uploadHelper')
+const imageService = require('~/services/image')
 
 const uploadImage = async (req, res) => {
   if (!req.file) {
     return createError(400, NO_FILE_UPLOADED)
   }
 
-  upload(req.file.buffer, (error, result) => {
+  upload(req.file.buffer, async (error, result) => {
     if (error) {
       return res.status(500).json({
         status: 500,
@@ -15,6 +16,9 @@ const uploadImage = async (req, res) => {
         message: 'Error uploading to Cloudinary'
       })
     }
+
+    await imageService.addImage(result.public_id, result.secure_url, req.user.id)
+
     res.status(200).json({ url: result.secure_url })
   })
 }

--- a/src/controllers/user.js
+++ b/src/controllers/user.js
@@ -1,9 +1,11 @@
 const userService = require('~/services/user')
+const imageService = require('~/services/image')
 const { createForbiddenError } = require('~/utils/errorsHelper')
 const createAggregateOptions = require('~/utils/users/createAggregateOptions')
 const { createError } = require('~/utils/errorsHelper')
 const { INTERNAL_SERVER_ERROR, NO_FILE_UPLOADED } = require('~/consts/errors')
 const { upload } = require('~/utils/uploadHelper')
+const logger = require('~/logger/logger')
 
 const getUsers = async (req, res) => {
   const { skip, limit, sort, match } = createAggregateOptions(req.query)
@@ -52,7 +54,23 @@ const uploadPhoto = async (req, res) => {
       })
     }
 
+    await imageService.addImage(result.public_id, result.secure_url, id)
+
+    const { photo } = await userService.getUserById(id)
+
     await userService.privateUpdateUser(id, { photo: result.secure_url })
+
+    try {
+      await imageService.deleteImageByUrl(photo)
+    } catch (err) {
+      logger.error(err)
+
+      return res.status(500).json({
+        status: 500,
+        code: INTERNAL_SERVER_ERROR.code,
+        message: 'Error destroing from Cloudinary'
+      })
+    }
 
     res.status(204).end()
   })

--- a/src/controllers/user.js
+++ b/src/controllers/user.js
@@ -61,14 +61,16 @@ const uploadPhoto = async (req, res) => {
     await userService.privateUpdateUser(id, { photo: result.secure_url })
 
     try {
-      await imageService.deleteImageByUrl(photo)
+      if (photo) {
+        await imageService.deleteImageByUrl(photo)
+      }
     } catch (err) {
       logger.error(err)
 
       return res.status(500).json({
         status: 500,
         code: INTERNAL_SERVER_ERROR.code,
-        message: 'Error destroing from Cloudinary'
+        message: 'Error destroying from Cloudinary'
       })
     }
 

--- a/src/models/image.js
+++ b/src/models/image.js
@@ -1,0 +1,19 @@
+const { Schema, model } = require('mongoose')
+const { IMAGE, USER } = require('~/consts/models')
+
+const imageSchema = new Schema({
+  publicId: {
+    type: String,
+    required: true
+  },
+  url: {
+    type: String,
+    required: true
+  },
+  uploadedBy: {
+    type: Schema.Types.ObjectId,
+    ref: USER
+  }
+})
+
+module.exports = model(IMAGE, imageSchema)

--- a/src/services/image.js
+++ b/src/services/image.js
@@ -1,0 +1,19 @@
+const Image = require('~/models/image')
+const { destroy } = require('~/utils/uploadHelper')
+
+const imageService = {
+  addImage: async (publicId, url, uploadedBy) => {
+    return Image.create({ publicId, url, uploadedBy })
+  },
+
+  deleteImageByUrl: async (url) => {
+    const image = await Image.findOne({ url }).lean().exec()
+
+    if (image?.publicId) {
+      await destroy(image.publicId)
+      await Image.findByIdAndRemove(image._id).exec()
+    }
+  }
+}
+
+module.exports = imageService

--- a/src/utils/uploadHelper.js
+++ b/src/utils/uploadHelper.js
@@ -7,10 +7,15 @@ cloudinary.config({
   api_secret: cloudinaryConfig.CLOUDINARY_API_SECRET
 })
 
+const destroy = async (publicId) => {
+  return cloudinary.uploader.destroy(publicId)
+}
+
 const upload = (buffer, callback) => {
   cloudinary.uploader.upload_stream({ resource_type: 'auto' }, callback).end(buffer)
 }
 
 module.exports = {
-  upload
+  upload,
+  destroy
 }


### PR DESCRIPTION
[[8](https://github.com/Space2Study-UA-4427-4288-02-02/BackEnd-03/issues/8)] Remove old photo from cloudinary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Backend now persists uploaded image metadata and links images to user accounts.
  - Added an image persistence service and storage deletion helper to manage image lifecycle.
- **Bug Fixes / Improvements**
  - Replaced profile photos are cleaned up automatically when a new photo is uploaded.
  - Upload flow made asynchronous for more reliable persistence while keeping existing success responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->