### PR TITLE
#102-createSubjectGetListGetNames

### DIFF
--- a/src/consts/errors.js
+++ b/src/consts/errors.js
@@ -103,6 +103,10 @@ const errors = {
     code: 'CATEGORY_NAME_NOT_UNIQUE',
     message: 'Category name not unique.'
   },
+  SUBJECT_NAME_NOT_UNIQUE: {
+    code: 'SUBJECT_NAME_NOT_UNIQUE',
+    message: 'Subject name not unique.'
+  },
   DOCUMENT_NOT_FOUND: (document) => ({
     code: 'DOCUMENT_NOT_FOUND',
     message: `${document} with the specified ${document.length > 1 ? 'IDs were' : 'ID was'} not found.`

--- a/src/controllers/subject.js
+++ b/src/controllers/subject.js
@@ -1,0 +1,29 @@
+const subjectService = require('~/services/subject')
+
+const createSubject = async (req, res) => {
+  const { name, categoryId } = req.body
+
+  const subject = await subjectService.createSubject(name, categoryId)
+
+  res.status(201).json(subject)
+}
+
+const getSubjects = async (_, res) => {
+  const subjects = await subjectService.getSubjects()
+
+  res.status(200).json(subjects)
+}
+
+const getSubjectsNames = async (req, res) => {
+  const { categoryId } = req.query
+
+  const subjectsNames = await subjectService.getSubjectsNames(categoryId)
+
+  res.status(200).json(subjectsNames)
+}
+
+module.exports = {
+  createSubject,
+  getSubjects,
+  getSubjectsNames
+}

--- a/src/docs/subject.yaml
+++ b/src/docs/subject.yaml
@@ -1,0 +1,169 @@
+paths:
+  /subjects:
+    post:
+      tags:
+        - Subject
+      summary: Create Subject
+      description: Add new subject.
+      produces:
+        - application/json
+      requestBody:
+        required: true
+        description: Provide required data to create subject.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: name
+                  example: subject name
+                categoryId:
+                  type: string
+                  description: categoryId
+                  example: 64b8f14016a65d17c0d22001
+              required:
+                - name
+                - categoryId
+            example:
+              name: subject name
+              categoryId: 64b8f14016
+      responses:
+        201:
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  name:
+                    type: string
+                    description: name
+                    example: subject name
+                  categoryId:
+                    type: string
+                    description: categoryId
+                    example: 64b8f14016a65d17c0d22001
+                required:
+                  - name
+                  - categoryId
+              example:
+                name: subject name
+                categoryId: 64b8f1401665d17c0d22001
+        400:
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: number
+                  code:
+                    type: string
+                  message:
+                    type: string
+              example:
+                status: 400
+                code: 'SUBJECT_NAME_NOT_UNIQUE'
+                message: 'Subject name not unique.'
+    get:
+      tags:
+        - Subject
+      summary: Get Subject List
+      description: Get Subject List.
+      produces:
+        - application/json
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                    name:
+                      type: string
+                    categoryId:
+                      type: string
+              example:
+                - _id: 'a8f14016a65d17c0d22001ad'
+                  name: name1
+                  categoryId: 64b8f14016a65d17c0d22001
+                - _id: 'b8f14016a65d17c0d22001ad'
+                  name: name2
+                  categoryId: 64b8f14016a65d17c0d22002
+        400:
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: number
+                  code:
+                    type: string
+                  message:
+                    type: string
+              example:
+                status: 401
+                code: 'UNAUTHORIZED'
+                message: 'The requested URL requires user authorization.'
+  /subjects/names:
+    get:
+      tags:
+        - Subject
+      summary: Get Subject Names List
+      description: Get Subject Names List.
+      produces:
+        - application/json
+      parameters:
+        - name: categoryId
+          in: query
+          description: Filter subjects by categoryId
+          required: false
+          schema:
+          type: string
+          example: 64b8f14016a65d17c0d22001
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                    name:
+                      type: string
+              example:
+                - _id: 'a8f14016a65d17c0d22001ad'
+                  name: name1
+                - _id: 'b8f14016a65d17c0d22001ad'
+                  name: name2
+        400:
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: number
+                  code:
+                    type: string
+                  message:
+                    type: string
+              example:
+                status: 401
+                code: 'UNAUTHORIZED'
+                message: 'The requested URL requires user authorization.'

--- a/src/docs/subject.yaml
+++ b/src/docs/subject.yaml
@@ -129,8 +129,8 @@ paths:
           description: Filter subjects by categoryId
           required: false
           schema:
-          type: string
-          example: 64b8f14016a65d17c0d22001
+            type: string
+            example: 64b8f14016a65d17c0d22001
       responses:
         200:
           description: OK

--- a/src/docs/subject.yaml
+++ b/src/docs/subject.yaml
@@ -99,7 +99,7 @@ paths:
                   name: name2
                   categoryId: 64b8f14016a65d17c0d22002
         400:
-          description: Bad Request
+          description: Unauthorized
           content:
             application/json:
               schema:

--- a/src/models/subject.js
+++ b/src/models/subject.js
@@ -1,0 +1,19 @@
+const { Schema, model } = require('mongoose')
+
+const { CATEGORY, SUBJECT } = require('~/consts/models')
+const { FIELD_CANNOT_BE_EMPTY } = require('~/consts/errors')
+
+const subjectSchema = new Schema({
+  name: {
+    type: String,
+    required: [true, FIELD_CANNOT_BE_EMPTY('name')],
+    unique: true
+  },
+  categoryId: {
+    type: Schema.Types.ObjectId,
+    ref: CATEGORY,
+    required: [true, FIELD_CANNOT_BE_EMPTY('categoryId')]
+  }
+})
+
+module.exports = model(SUBJECT, subjectSchema)

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -9,6 +9,7 @@ const resourcesCategory = require('~/routes/resourcesCategory')
 const offer = require('~/routes/offer')
 const uploadImage = require('~/routes/uploadImage')
 const category = require('~/routes/category')
+const subject = require('~/routes/subject')
 
 router.use('/auth', auth)
 router.use('/users', user)
@@ -19,5 +20,6 @@ router.use('/resources-categories', resourcesCategory)
 router.use('/offers', offer)
 router.use('/uploadImage', uploadImage)
 router.use('/categories', category)
+router.use('/subjects', subject)
 
 module.exports = router

--- a/src/routes/subject.js
+++ b/src/routes/subject.js
@@ -1,0 +1,27 @@
+const router = require('express').Router()
+
+const langMiddleware = require('~/middlewares/appLanguage')
+const asyncWrapper = require('~/middlewares/asyncWrapper')
+const { restrictTo, authMiddleware } = require('~/middlewares/auth')
+const validationMiddleware = require('~/middlewares/validation')
+
+const subjectValidationSchema = require('~/validation/schemas/subject')
+
+const subjectController = require('~/controllers/subject')
+const {
+  roles: { ADMIN, SUPERADMIN }
+} = require('~/consts/auth')
+
+router.use(authMiddleware)
+router.get('/', langMiddleware, asyncWrapper(subjectController.getSubjects))
+router.get('/names', langMiddleware, asyncWrapper(subjectController.getSubjectsNames))
+
+router.use(restrictTo(ADMIN, SUPERADMIN))
+router.post(
+  '/',
+  validationMiddleware(subjectValidationSchema),
+  langMiddleware,
+  asyncWrapper(subjectController.createSubject)
+)
+
+module.exports = router

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -56,13 +56,13 @@ const authService = {
       throw createError(401, INCORRECT_CREDENTIALS)
     }
 
-    const { _id, lastLoginAs, isFirstLogin, isEmailConfirmed } = user
+    const { _id, lastLoginAs, isFirstLogin, isEmailConfirmed, role } = user
 
     if (!isEmailConfirmed) {
       throw createError(401, EMAIL_NOT_CONFIRMED)
     }
 
-    const tokens = tokenService.generateTokens({ id: _id, role: lastLoginAs, isFirstLogin })
+    const tokens = tokenService.generateTokens({ id: _id, role: lastLoginAs || role?.[0], isFirstLogin })
     await tokenService.saveToken(_id, tokens.refreshToken, REFRESH_TOKEN)
 
     if (isFirstLogin) {

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -13,7 +13,8 @@ const {
 } = require('~/consts/errors')
 const emailSubject = require('~/consts/emailSubject')
 const {
-  tokenNames: { REFRESH_TOKEN, RESET_TOKEN, CONFIRM_TOKEN }
+  tokenNames: { REFRESH_TOKEN, RESET_TOKEN, CONFIRM_TOKEN },
+  roles: { STUDENT }
 } = require('~/consts/auth')
 
 const { OAuth2Client } = require('google-auth-library')
@@ -62,7 +63,9 @@ const authService = {
       throw createError(401, EMAIL_NOT_CONFIRMED)
     }
 
-    const tokens = tokenService.generateTokens({ id: _id, role: lastLoginAs || role?.[0], isFirstLogin })
+    const userRole = lastLoginAs || role?.[0] || STUDENT
+
+    const tokens = tokenService.generateTokens({ id: _id, role: userRole, isFirstLogin })
     await tokenService.saveToken(_id, tokens.refreshToken, REFRESH_TOKEN)
 
     if (isFirstLogin) {
@@ -86,9 +89,11 @@ const authService = {
       throw createError(400, BAD_REFRESH_TOKEN)
     }
 
-    const { _id, lastLoginAs, isFirstLogin } = await getUserById(tokenData.id)
+    const { _id, lastLoginAs, isFirstLogin, role } = await getUserById(tokenData.id)
 
-    const tokens = tokenService.generateTokens({ id: _id, role: lastLoginAs, isFirstLogin })
+    const userRole = lastLoginAs || role?.[0] || STUDENT
+
+    const tokens = tokenService.generateTokens({ id: _id, role: userRole, isFirstLogin })
     await tokenService.saveToken(_id, tokens.refreshToken, REFRESH_TOKEN)
 
     return tokens

--- a/src/services/subject.js
+++ b/src/services/subject.js
@@ -1,0 +1,36 @@
+const mongoose = require('mongoose')
+
+const Subject = require('~/models/subject')
+const { createError } = require('~/utils/errorsHelper')
+const { SUBJECT_NAME_NOT_UNIQUE, INVALID_ID } = require('~/consts/errors')
+
+const subjectService = {
+  createSubject: async (name, categoryId) => {
+    const duplicateSubject = await Subject.findOne({ name }).lean().exec()
+
+    if (duplicateSubject) {
+      throw createError(400, SUBJECT_NAME_NOT_UNIQUE)
+    }
+
+    return await Subject.create({
+      name,
+      categoryId
+    })
+  },
+
+  getSubjects: async () => {
+    return await Subject.find().lean().exec()
+  },
+
+  getSubjectsNames: async (categoryId) => {
+    if (categoryId && !mongoose.Types.ObjectId.isValid(categoryId)) {
+      throw createError(400, INVALID_ID)
+    }
+
+    return await Subject.find(categoryId ? { categoryId } : null)
+      .select('name')
+      .exec()
+  }
+}
+
+module.exports = subjectService

--- a/src/test/integration/controllers/auth.spec.js
+++ b/src/test/integration/controllers/auth.spec.js
@@ -12,9 +12,6 @@ jest.mock('google-auth-library', () => ({
   OAuth2Client: jest.fn()
 }))
 
-jest.mock('~/services/user')
-jest.mock('~/services/token')
-
 describe('Auth controller', () => {
   let app, server, signupResponse
 

--- a/src/validation/schemas/subject.js
+++ b/src/validation/schemas/subject.js
@@ -1,0 +1,12 @@
+const subjectValidationSchema = {
+  name: {
+    type: 'string',
+    required: true
+  },
+  categoryId: {
+    type: 'string',
+    required: true
+  }
+}
+
+module.exports = subjectValidationSchema


### PR DESCRIPTION
Instruction:
1) You should have confirmed account with role "admin" or "superadmin" 
2) Login with user (from step 1)
3) Create new category
```
POST http://localhost:3000/categories
{
  "name": "category name",
  "appearance": {
    "icon": "icon",
    "color": "color"
  }
}
```
4) Extract category id
`GET http://localhost:3000/categories/names`
5) Create new subject with categoryId from step 4
```
POST http://localhost:3000/subjects
{
  "name": "subject name",
  "categoryId": "64b8f14016"
}
```
6) Finally get subject names 
`GET http://localhost:3000/subjects/names?categoryId=64b8f14016a65d17c0d22001`
_* if you do not provide categoryId api will return all subject names without filtering it_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added subject management API: create subjects, list subjects, and retrieve subject names; creation restricted to admin roles and supports category filtering.

* **Documentation**
  * Added OpenAPI spec for Subject endpoints with request/response examples and consistent error schemas.

* **Errors**
  * Introduced SUBJECT_NAME_NOT_UNIQUE error code for duplicate subject names.

* **Tests**
  * Updated auth integration tests to use real service behavior (removed two specific mocks).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->